### PR TITLE
Update k8s version

### DIFF
--- a/content/extend/content.md
+++ b/content/extend/content.md
@@ -21,8 +21,8 @@ New extensions to CrownLabs services may require to enrich both the backend and 
 With respect to the backend (Kubernetes), the glue logic comes as [Custom Resources (CRD)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/), mainly written in GO language.
 Extending the platform may require to create new Kubernetes operators implementing the desired services.
 
-With respect to the frontent (web browser), the glue logic is oriented to present a minimal dashboard to students and instructors and it is mainly written in Javascript, exploiting the [React](https://reactjs.org/) library and [Material-UI](https://material-ui.com/) components.
-In this case, extending the platform may require to create the proper Javascript front-end that interfaces with the new Kubernetes operators mentioned above.
+With respect to the frontend (web browser), the glue logic is oriented to present a minimal dashboard to students and instructors and it is mainly written in TypeScript, exploiting the [React](https://reactjs.org/) library and [Antd](https://https://ant.design/) components.
+In this case, extending the platform may require to create the proper TypeScript front-end that interfaces with the new Kubernetes operators mentioned above.
 
 More information is available on GitHub, in the sections dedicated to the CrownLabs [Operators](https://github.com/netgroup-polito/CrownLabs/tree/master/operators) and [Web frontend](https://github.com/netgroup-polito/CrownLabs/tree/master/webservice).
 

--- a/content/extend/content.md
+++ b/content/extend/content.md
@@ -21,7 +21,7 @@ New extensions to CrownLabs services may require to enrich both the backend and 
 With respect to the backend (Kubernetes), the glue logic comes as [Custom Resources (CRD)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/), mainly written in GO language.
 Extending the platform may require to create new Kubernetes operators implementing the desired services.
 
-With respect to the frontend (web browser), the glue logic is oriented to present a minimal dashboard to students and instructors and it is mainly written in TypeScript, exploiting the [React](https://reactjs.org/) library and [Antd](https://https://ant.design/) components.
+With respect to the frontend (web browser), the glue logic is oriented to present a minimal dashboard to students and instructors and it is mainly written in TypeScript, exploiting the [React](https://reactjs.org/) library and [Antd](https://ant.design/) components.
 In this case, extending the platform may require to create the proper TypeScript front-end that interfaces with the new Kubernetes operators mentioned above.
 
 More information is available on GitHub, in the sections dedicated to the CrownLabs [Operators](https://github.com/netgroup-polito/CrownLabs/tree/master/operators) and [Web frontend](https://github.com/netgroup-polito/CrownLabs/tree/master/webservice).

--- a/content/resources/sandbox/sandbox.md
+++ b/content/resources/sandbox/sandbox.md
@@ -17,7 +17,7 @@ In case of problems, or if you want to request the creation of a sandbox namespa
 In order to access your **sandbox namespace** on CrownLabs, it is necessary to first install **kubectl**, the Kubernetes command-line tool that allows to run commands against Kubernetes clusters.
 You can refer to the [official documentation](https://kubernetes.io/docs/tasks/tools/) to discover how to download and install **kubectl** on your preferred operating system.
 
-**Note:** you should make sure the selected kubectl version is compatible with the CrownLabs cluster, according to the [version skew policy](https://kubernetes.io/releases/version-skew-policy/#kubectl). The CrownLabs cluster is currently based on Kubernetes v1.21, hence versions 1.20.x, 1.21.x and 1.22.x of kubectl are officially supported.
+**Note:** you should make sure the selected kubectl version is compatible with the CrownLabs cluster, according to the [version skew policy](https://kubernetes.io/releases/version-skew-policy/#kubectl). The CrownLabs cluster is currently based on Kubernetes v1.28, hence versions 1.27.x, 1.28.x and 1.29.x of kubectl are officially supported.
 
 **Note:** you may also install kubectl and perform the following configurations on a CrownLabs instance, if you are not using your own PC (e.g., you are in a PoliTO laboratory).
 


### PR DESCRIPTION
We only updated the k8s version present in the sandbox tutorial.
We do not know if we have to update the `date` field on top of that page.